### PR TITLE
 Fixed typo in disable_OPENCL variable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,7 +47,7 @@ if(ENABLE_CL_SUPPORT)
   endif()
 endif()
 if(NOT ENABLE_CL_SUPPORT)
-  add_definitions( -DOPI_DISABLE_CL )
+    add_definitions( -DOPI_DISABLE_OPENCL )
 endif()
 
 # enable all warnings


### PR DESCRIPTION
Fixed simple type that lead to a compile error in case open_cl is not available on computer.