### PR TITLE
Fix call of opi_propagator_propagate

### DIFF
--- a/examples/host_fortran_example.f90
+++ b/examples/host_fortran_example.f90
@@ -50,7 +50,7 @@ program opi_host_fortran_test
       OPI_Module_getPropertyString(propagator, i -1)
     end do
     ! run propagation of our test propagator
-    status = OPI_Propagator_propagate(propagator, data, 0.d0, 0.0)
+    status = OPI_Propagator_propagate(propagator, data, 0.d0, 0.d0)
 
     ! retrieve orbital data values
     orbit => OPI_Population_getOrbit(data)


### PR DESCRIPTION
Micro commit: Corrected type of variable in call of named routine.

... was 0.0, is not 0.d0. Otherwise, compilation might fail, depending on compiler flags.